### PR TITLE
3better validate

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/make-this-website-better.iml
+++ b/.idea/make-this-website-better.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/make-this-website-better.iml" filepath="$PROJECT_DIR$/.idea/make-this-website-better.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/index.html
+++ b/index.html
@@ -1,89 +1,91 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title>Register to work at Etch</title>
+    <meta charset='UTF-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#111111">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/normalize-css@2.3.1/normalize.css">
     <link rel="stylesheet" href="./style.css">
+    <script defer src="./script.js"></script>
   </head>
   <body>
-    <div class="page">
-      <div class="navbar">
-        <img class="navbar__logo" src="./assets/logo.svg">
+    <nav>
+      <img src="./assets/logo.svg" alt="Etch logo" />
+      <div>
+        <a href="https://etch.co/team">Team</a>
+        <a href="https://etch.co/work">Work</a>
+      </div>
+    </nav>
 
-        <div class="navbar__links">
-          <a href="https://etch.co/team" target="_blank" class="navbar__link">Team</a>
-          <a href="https://etch.co/work" target="_blank" class="navbar__link">Work</a>
-          <a href="https://etch.co/makes" target="_blank" class="navbar__link">Makes</a>
-          <a href="https://etch.co/the" target="_blank" class="navbar__link">The</a>
-          <a href="https://etch.co/dream" target="_blank" class="navbar__link">Dream</a>
-          <a href="https://etch.co/work" target="_blank" class="navbar__link">Work</a>
+    <header>
+      <h1 class="title">Register to work at Etch</h1>
+      <p class="subtitle">
+        Simply fill in this form with your details to register your
+        interest for working at <a href="https://etch.co" target="_blank">Etch</a>.
+      </p>
+    </header>
+
+    <main>
+      <form id="123456" action="https://formspree.io/f/xaylazjw" method="POST">
+        <div>
+          <label for="form-name">
+            Name*
+          </label>
+          <input id="form-name" type="text" name="name" required />
         </div>
-      </div>
-      <div class="hero">
-        <h1 class="hero__title">Register to work at Etch</h1>
-        <p class="hero__subtitle">
-          Simply fill in this form with your details to register your 
-          interest for working at <a href="https://etch.co" target="_blank">Etch</a>.
-        </p>
-      </div>
-      
-      <div class="main">
-        <form class="form" action="https://formspree.io/f/xaylazjw" method="POST">
-          <input type="hidden" name="id" value="123456">
 
-          <div class="form-group">
-            <label class="form-group__label">Name</label>
-            <input class="form-group__input" type="text" name="name">
-          </div>
+        <div>
+          <label for="form-email">
+            Email*
+          </label>
+          <input id="form-email" type="text" name="email" required />
+        </div>
 
-          <div class="form-group">
-            <label class="form-group__label">Email</label>
-            <input class="form-group__input" type="text" name="email">
-          </div>
+        <div>
+          <label for="form-tel">
+            Telephone number
+          </label>
+          <input id="form-tel" type="text" name="telephone" />
+        </div>
 
-          <div class="form-group">
-            <label class="form-group__label">Date of birth</label>
-            <input class="form-group__input" type="text" name="dob">
-          </div>
+        <div>
+          <fieldset>
+            <legend>Favourite web development topics</legend>
+            <label>
+              Hex colours
+              <input type="checkbox" name="fave0" />
+            </label>
+            <label>
+              Accessibility
+              <input type="checkbox" name="fave1" />
+            </label>
+            <label>
+              Node modules
+              <input type="checkbox" name="fave2" />
+            </label>
+            <label>
+              JavaScript frameworks
+              <input type="checkbox" name="fave3" />
+            </label>
+            <label>
+              BBQ
+              <input type="checkbox" name="fave4" />
+            </label>
+          </fieldset>
+        </div>
 
-          <div class="form-group">
-            <label class="form-group__label">Telephone number</label>
-            <input class="form-group__input" type="text" name="telephone">
-          </div>
+        <div>
+          <label for="form-why">Why I want to work at Etch</label>
+          <textarea id="form-why" name="why"></textarea>
+        </div>
 
-          <div class="form-group">
-            <label class="form-group__label">Address</label>
-            <input class="form-group__input" type="text" name="address">
-          </div>
+        <button disabled>I want to work at Etch</button>
+      </form>
+    </main>
 
-          <div class="form-group">
-            <label class="form-group__label">Number of years experience</label>
-            <input class="form-group__input" type="text" name="years">
-          </div>
-
-          <div class="form-group">
-            <label class="form-group__label">Favourite web development topics</label>
-            <input class="form-group__checkbox" type="checkbox" name="faves[]"> Hex colours<br />
-            <input class="form-group__checkbox" type="checkbox" name="faves[]"> Accessibility<br />
-            <input class="form-group__checkbox" type="checkbox" name="faves[]"> Node modules<br />
-            <input class="form-group__checkbox" type="checkbox" name="faves[]"> Javascript frameworks<br />
-            <input class="form-group__checkbox" type="checkbox" name="faves[]"> BBQ<br />
-          </div>
-          
-          <div class="form-group">
-            <label class="form-group__label">Why I want to work at Etch</label>
-            <textarea name="why" class="form-group__input"></textarea>
-          </div>
-
-
-          <button>I want to work at Etch</button>
-        </form>
-      </div>
-
-      <div class="footer">
-        &copy;2020 Etch Software Ltd.
-      </div>
-    </div>
-    <script src="./script.js"></script>
+    <footer>
+      &copy;2021 Etch Software Ltd.
+    </footer>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <label for="name">
             Name
           </label>
-          <div class="req req-name">required. 3+ characters</div>
+          <div class="req req-name">give us a name! 3-50 char</div>
           <input id="name" type="text" name="name" required />
         </div>
 
@@ -40,7 +40,7 @@
           <label for="email">
             Email
           </label>
-          <div class="req req-email">required. must be valid!</div>
+          <div class="req req-email">must be valid!</div>
           <input id="email" type="text" name="email" required />
         </div>
 
@@ -49,6 +49,13 @@
             Telephone number
           </label>
           <input id="telephone" type="text" name="telephone" />
+        </div>
+
+        <div>
+          <label for="website">
+            Link to something you've done
+          </label>
+          <input id="website" type="text" name="website" />
         </div>
 
         <div>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
           <label for="name">
             Name
           </label>
-          <div class="req req-name">required. 3+ char</div>
+          <div class="req req-name">required. 3+ characters</div>
           <input id="name" type="text" name="name" required />
         </div>
 

--- a/index.html
+++ b/index.html
@@ -29,24 +29,26 @@
     <main>
       <form id="123456" action="https://formspree.io/f/xaylazjw" method="POST">
         <div>
-          <label for="form-name">
-            Name*
+          <label for="name">
+            Name
           </label>
-          <input id="form-name" type="text" name="name" required />
+          <div class="req req-name">required. 3+ char</div>
+          <input id="name" type="text" name="name" required />
         </div>
 
         <div>
-          <label for="form-email">
-            Email*
+          <label for="email">
+            Email
           </label>
-          <input id="form-email" type="text" name="email" required />
+          <div class="req req-email">required. must be valid!</div>
+          <input id="email" type="text" name="email" required />
         </div>
 
         <div>
-          <label for="form-tel">
+          <label for="telephone">
             Telephone number
           </label>
-          <input id="form-tel" type="text" name="telephone" />
+          <input id="telephone" type="text" name="telephone" />
         </div>
 
         <div>
@@ -76,12 +78,17 @@
         </div>
 
         <div>
-          <label for="form-why">Why I want to work at Etch</label>
-          <textarea id="form-why" name="why"></textarea>
+          <label for="why">
+            Why I want to work at Etch
+          </label>
+          <div class="req req-name">200-2000 char</div>
+          <textarea id="why" name="why" minlength="200" maxlength="2000" required></textarea>
+          <div class="req req-why"><span>0</span>/2000</div>
         </div>
 
         <button disabled>I want to work at Etch</button>
       </form>
+      <div class="message"></div>
     </main>
 
     <footer>

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ const namePattern = new RegExp(/^(?=.{3,50}$)[a-zA-Z]+/);
 const emailPattern = new RegExp(/^(("[\w-\s]+")|([\w-]+(?:\.[\w-]+)*)|("[\w-\s]+")([\w-]+(?:\.[\w-]+)*))(@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$)|(@\[?((25[0-5]\.|2[0-4][0-9]\.|1[0-9]{2}\.|[0-9]{1,2}\.))((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){2}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\]?$)/);
 
 document.addEventListener('keyup', () => {
-    validateForm() ? submitButton.disabled = false : submitButton.disabled = true;
+    submitButton.disabled = !validateForm();
     whyReq.textContent = why.value.length;
 });
 
@@ -21,12 +21,7 @@ let getFormData = () => {
 let validateForm = () => {
     let success = true;
     let data = getFormData();
-    if (!namePattern.test(data.name)
-        || !emailPattern.test(data.email)
-        || data.why.length < 200
-        || data.why.length > 2000) {
+    if (!namePattern.test(data.name) || !emailPattern.test(data.email) || data.why.length < 200 || data.why.length > 2000) {
         success = false;
-    }
-    return success;
+    } return success;
 }
-

--- a/script.js
+++ b/script.js
@@ -1,1 +1,32 @@
-console.log('Connected!')
+const registerForm = document.querySelector('form');
+const why = document.querySelector('#why');
+const whyReq = document.querySelector('.req-why span');
+const submitButton = document.querySelector('button');
+const namePattern = new RegExp(/^(?=.{3,50}$)[a-zA-Z]+/);
+const emailPattern = new RegExp(/^(("[\w-\s]+")|([\w-]+(?:\.[\w-]+)*)|("[\w-\s]+")([\w-]+(?:\.[\w-]+)*))(@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$)|(@\[?((25[0-5]\.|2[0-4][0-9]\.|1[0-9]{2}\.|[0-9]{1,2}\.))((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\.){2}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[0-9]{1,2})\]?$)/);
+
+document.addEventListener('keyup', () => {
+    validateForm() ? submitButton.disabled = false : submitButton.disabled = true;
+    whyReq.textContent = why.value.length;
+});
+
+let getFormData = () => {
+    return {
+        name: registerForm.elements['name'].value,
+        email: registerForm.elements['email'].value,
+        why: registerForm.elements['why'].value
+    }
+}
+
+let validateForm = () => {
+    let success = true;
+    let data = getFormData();
+    if (!namePattern.test(data.name)
+        || !emailPattern.test(data.email)
+        || data.why.length < 200
+        || data.why.length > 2000) {
+        success = false;
+    }
+    return success;
+}
+

--- a/style.css
+++ b/style.css
@@ -102,6 +102,10 @@ input[type='checkbox'] {
   color: #7d79af;
 }
 
+.alert {
+  color: red;
+}
+
 button {
   margin: 1em auto;
   padding: 5px 10px;

--- a/style.css
+++ b/style.css
@@ -59,7 +59,7 @@ header a {
 
 main {
   margin: auto;
-  padding: 5%;
+  padding: 3vh;
 }
 
 form {
@@ -69,7 +69,7 @@ form {
 }
 
 form div {
-  margin: 1em auto;
+  margin: 2em auto;
   text-align: left;
 }
 
@@ -92,6 +92,14 @@ fieldset label {
 
 input[type='checkbox'] {
   width: 1em;
+}
+
+.req {
+  float: right;
+  margin: 0;
+  font-size: x-small;
+  text-align: right;
+  color: #7d79af;
 }
 
 button {

--- a/style.css
+++ b/style.css
@@ -1,63 +1,120 @@
-body {
-  margin: 0;
-  padding: 0;
-}
+@import url('https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;900&display=swap');
 
-.page {
+body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  font-family: 'Nunito Sans', sans-serif;
+  font-weight: 400;
 }
 
-.navbar {
-  align-items: center;
-  background: black;
-  display: flex;
-  padding: 1em;
-}
-
-.navbar__logo {
-  height: 32px;
-  margin-right: 2em;
-  width: 76px;
-}
-
-.navbar__links {
-  display: flex;
-}
-
-.navbar__link {
-  color: white;
-  margin: 0 .5em;
+a {
   text-decoration: none;
 }
 
-.hero {
-  background: #999;
-  padding: 5%;
+a:hover {
+  text-decoration: underline;
 }
 
-.main {
-  flex: 1 1 auto;
+nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  background: #000000;
+  padding: 1em;
+}
+
+nav img {
+  width: 76px;
+  height: 32px;
+  margin: auto 1em;
+}
+
+nav div {
   margin: auto;
-  max-width: 40em;
+}
+
+nav a {
+  margin: 0.5em;
+  color: #ffffff;
+  font-weight: 900;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+header, footer {
+  padding: 5%;
+  text-align: center;
+  color: #ffffff;
+  background: linear-gradient(to bottom right, #ff4848, #6b5bff);
+}
+
+header a {
+  color: #ffffff;
+  font-weight: 900;
+}
+
+main {
+  margin: auto;
   padding: 5%;
 }
 
-.footer {
-  background: #999;
-  padding: 5%;
+form {
+  width: 340px;
+  text-align: center;
+  line-height: 2em;
 }
 
-.form-group {
-  margin-bottom: 1em;
+form div {
+  margin: 1em auto;
+  text-align: left;
 }
 
-.form-group__label {
-  display: block;
-}
-
-.form-group__input {
-  display: block;
+input, textarea, fieldset {
   width: 100%;
+}
+
+fieldset {
+  padding: 0;
+  text-align: left;
+  border: 0;
+}
+
+fieldset label {
+  display: flex;
+  justify-content: space-between;
+  width: 70%;
+  margin: auto;
+}
+
+input[type='checkbox'] {
+  width: 1em;
+}
+
+button {
+  margin: 1em auto;
+  padding: 5px 10px;
+  color: #ffffff;
+  border: 0;
+  border-radius: 5px;
+  background: #6b5bff;
+}
+
+button:disabled {
+  background: #7d79af;
+}
+
+@media screen and (max-width: 800px) {
+
+  nav {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  form {
+    width: 100%;
+  }
+
 }


### PR DESCRIPTION
- changed classes to relevant html tags (e.g. .navbar -> nav)
[more semantic; less code]

- changed relevant classes to parent-child relationships (e.g. .navbar__link -> nav a)
[more semantic; makes later changes easier]

- added language tag, meta tags

- added 'alt' text to img
[accessibility]

- made nav bar links look more like real site (centred, uppercase)
[making some effort to mirror the real Etch site, but don't feel this page needs the same kind of 'pzazz' as the rest of the site]

- made page look a little prettier (e.g. linear gradient bg)

- removed some input fields (DOB, address, years experience)
[maybe not relevant; experience should be apparent from CV/portfolio/cover letter]

- fieldset & legend for checkboxes
- changed names for checkboxes (numbered 0-4)
- added 'for' for all labels

- switched up quite a bit of other CSS
[just making it more like something I would have written from the beginning]

- added field for linking to a website
[considered adding an upload field for a CV, maybe sent to dropbox or similar, but thought that might have been going a bit far]

- added very simple JS validation on the form
[regex to make sure name is not just a couple of letters; regex to validate email; check to make sure length of textarea isn't really short or really long]

- simple event listener for keyup to (1) validate as typing, (2) show character count for textarea

- submit button disabled until validation success
[I just find it quite satisfying]

- added max-width media query to CSS for mobile
[normally might have done mobile-first]

- possibly some things I've forgotten